### PR TITLE
Fix multiple import

### DIFF
--- a/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
+++ b/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
@@ -1,4 +1,3 @@
-import secure_smtpd
 import smtpd
 import base64
 import secure_smtpd


### PR DESCRIPTION
## Description 

While browsing through the Code and studying it for better understanding, I found minor bugs and anti-patterns that can be possibly improved to mitigate any potential bug. Since this is the first time, when I'm contributing to OWASP, I wanted to get a better understanding of the Codebase and make contributions on the same. 

## Changes Done 

The following commits have been made on the Codebase: 

- Fixing the multiple error issue

I found the `secure_smtpd` package was imported twice in the same file. I fixed it according to the PEP8 standard. There were some more issues with respect to PEP8 formatting as per PyLint but I would like to know, if PEP8 is strictly enforced on the Codebase.