### PR TITLE
fix : T217

### DIFF
--- a/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
+++ b/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
@@ -1,3 +1,4 @@
+import secure_smtpd
 import smtpd
 import base64
 import secure_smtpd

--- a/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
+++ b/modules/smtp/strong_password/files/smtpd_server/secure_smtpd/smtp_channel.py
@@ -1,4 +1,3 @@
-import secure_smtpd
 import smtpd
 import base64
 import secure_smtpd

--- a/modules/ssh/strong_password/Dockerfile
+++ b/modules/ssh/strong_password/Dockerfile
@@ -1,8 +1,9 @@
 # using phusion/baseimage as base image
-FROM phusion/baseimage:0.9.19
+FROM ubuntu:20.04
 
 # update and install openssh + python
-RUN apt-get update && apt-get install -y python3.5 python3-pip libffi-dev
+RUN apt-get update && apt-get install -y python3.5 python3-pip \
+    libffi-dev python3-dev libssl-dev build-essential openssh-client
 
 RUN pip3 install paramiko
 RUN pip3 install datetime


### PR DESCRIPTION
fix for https://github.com/OWASP/Python-Honeypot/issues/217

what:
paramiko has a dependency with cryptography, and for installing cryptography
openssl 1.1 or higher is needed. with phusion/base_image we get openssl 1.0,
hence changed the base image as ubuntu 20.04