### PR TITLE
Cleaning code in compatible.py

### DIFF
--- a/core/compatible.py
+++ b/core/compatible.py
@@ -71,15 +71,15 @@ def check_for_requirements(start_api_server):
     api_config = api_configuration()
     connection_timeout = api_config["api_database_connection_timeout"]
     try:
-        import pymongo
-        import netaddr
-        import flask
-        del netaddr
-        del flask
+        with open(os.path.join(os.getcwd(), 'requirements.txt'), 'r') as requirements:
+            for dependency in requirements:
+                dependency_name = dependency.split('=')[0]
+                __import__(dependency_name)
     except Exception:
         exit_failure("pip install -r requirements.txt")
     # check mongodb
     try:
+        import pymongo
         connection = pymongo.MongoClient(
             api_config["api_database"],
             serverSelectionTimeoutMS=connection_timeout


### PR DESCRIPTION
Old
```py
    try:
          import pymongo       
          import netaddr        
          import flask        
          del netaddr        
          del flask
    except Exception:
        exit_failure("pip install -r requirements.txt")
```
New
```py
    try:
        with open(os.path.join(os.getcwd(), 'requirements.txt'), 'r') as requirements:
            for dependency in requirements:
                dependency_name = dependency.split('=')[0]
                exec("import " + dependency_name)
    except Exception:
        exit_failure("pip install -r requirements.txt")
```
Reading all dependencies from `requirements.txt` file and checking they are installed using `exec` command by importing them.