### PR TITLE
Adding scroll in `/api/events/explore/<event_type>` Api

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -9,24 +9,20 @@ from flask import (Flask,
                    render_template,
                    send_file)
 from flask import request as flask_request
-from api.database_queries import (sort_by_count,
-                                  filter_by_date,
-                                  filter_by_skip,
-                                  filter_by_limit,
-                                  filter_by_country_ip_dest,
-                                  filter_by_module_name,
-                                  filter_by_match,
-                                  filter_by_regex,
-                                  event_types,
-                                  group_by_elements,
-                                  filter_by_element)
-from api.utility import (aggregate_function,
-                         all_mime_types,
-                         fix_limit,
-                         fix_skip,
-                         fix_filter_query,
-                         msg_structure,
-                         root_dir)
+from api.database_queries import (
+    filter_by_date,
+    filter_by_module_name,
+    filter_by_regex,
+    event_types,
+    group_by_elements,
+    filter_by_element)
+from api.utility import (
+    all_mime_types,
+    fix_limit,
+    fix_skip,
+    fix_filter_query,
+    msg_structure,
+    root_dir)
 from config import api_configuration
 from core.alert import write_to_api_console
 from core.get_modules import load_all_modules
@@ -297,9 +293,7 @@ def groupby_element(event_type, element):
     Returns:
         JSON/Dict top ten element in event type
     """
-    abort(404) if (
-            event_type not in event_types or element not in group_by_elements
-    ) else True
+    abort(404) if (event_type not in event_types or element not in group_by_elements) else True
     date = get_value_from_request("date")
     filter_by = get_value_from_request('filter_by')
     element_value = get_value_from_request(filter_by)
@@ -325,13 +319,12 @@ def groupby_element(event_type, element):
     try:
         return jsonify(
             {
-                record["key"]: record["doc_count"]
-                for record in elasticsearch_events.search(
-                    index=event_types[event_type], body=query, size=0
-                )["aggregations"]["ips"]["buckets"]
+                record["key"]: record["doc_count"] for record in
+                elasticsearch_events.search(index=event_types[event_type],
+                                            body=query,
+                                            size=0)["aggregations"]["ips"]["buckets"]
             }
         ), 200
-
     except Exception:
         abort(500)
 
@@ -371,14 +364,24 @@ def get_events_data(event_type):
                     fix_filter_query(filter_by)[key]
                 )
                 query['query']['bool']['filter'].append(filter_query)
-
-        return jsonify({
-            "total": int(
-                elasticsearch_events.count(
-                    index=event_types[event_type],
-                    body=query
-                )['count']),
-            "data": [
+        records = []
+        if get_value_from_request("limit") == "infinite":
+            data = elasticsearch_events.search(
+                index=event_types[event_type],
+                body=query,
+                scroll="2m",
+                size=10000
+            )
+            scroll_id = data['_scroll_id']
+            scroll_size = len(data['hits']['hits'])
+            while scroll_size > 0:
+                for record in data['hits']['hits']:
+                    records.append(record['_source'])
+                data = elasticsearch_events.scroll(scroll_id=scroll_id, scroll='2m')
+                scroll_id = data['_scroll_id']
+                scroll_size = len(data['hits']['hits'])
+        else:
+            records = [
                 record['_source'] for record in elasticsearch_events.search(
                     index=event_types[event_type],
                     body=query,
@@ -390,8 +393,15 @@ def get_events_data(event_type):
                     )
                 )['hits']['hits']
             ]
+        return jsonify({
+            "total": int(
+                elasticsearch_events.count(
+                    index=event_types[event_type],
+                    body=query
+                )['count']),
+            "data": records
         }), 200
-    except Exception as _:
+    except Exception:
         abort(500)
 
 

--- a/api/utility.py
+++ b/api/utility.py
@@ -165,6 +165,8 @@ def fix_limit(limit):
     """
     if limit:
         try:
+            if int(limit) > 10000:
+                return 10000
             return int(limit)
         except Exception:
             pass

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -121,7 +121,7 @@ class TestConnector(unittest.TestCase):
             data="Test Data"
         )
 
-        insert_to_events_data_collection(event_dwata)
+        insert_to_events_data_collection(event_data)
 
         # Find the record in the DB
         event_record_data = data_events.find_one(event_data.__dict__)


### PR DESCRIPTION
Adding scroll in `/api/events/explore/<event_type>` Api.
When all records needed to be fetched with a specific query. We can specify `limit=infinte` in query params to fetch all records in one go. If one specifies `limit > 10000` it will be set to 10000