### PR TITLE
fix es credential key from config

### DIFF
--- a/core/compatible.py
+++ b/core/compatible.py
@@ -89,7 +89,7 @@ def check_for_requirements(start_api_server):
     try:
         connection = elasticsearch.Elasticsearch(
             api_config["api_database"],
-            http_auth=api_config["api_database"]
+            http_auth=api_config["api_database_http_auth"]
         )
         connection.indices.get_alias("*")
     except Exception:


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
The wrong key was being used to select es credentials from the config file


## Reviewers
@Ali-Razmjoo @dhirensr 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have referenced the corresponding issue number in my commit message
- [x] My branch is up-to-date with the Upstream master branch.
