### PR TITLE
fix - kill network capture process if any container is killed

### DIFF
--- a/core/load.py
+++ b/core/load.py
@@ -363,15 +363,16 @@ def wait_until_interrupt(virtual_machine_container_reset_factory_time_seconds, c
                 start_containers(configuration)
             if not new_network_events_thread.is_alive():
                 error(messages["interrupt_application"])
-                return True
-
+                new_network_events_thread.terminate()
+                break
             if containers_are_unhealthy(configuration):
                 error(
                     "Interrupting the application because \"{0}\" container(s) is(are) not alive!".format(
                         ", ".join(containers_are_unhealthy(configuration))
                     )
                 )
-                return True
+                new_network_events_thread.terminate()
+                break
             if run_as_test:
                 break
         except KeyboardInterrupt:
@@ -887,9 +888,6 @@ def load_honeypot_engine():
     )
     # killed the network traffic capture process by ctrl + c... waiting to end.
     info(messages["killing_capture_process"])
-    if exit_flag:
-        # Terminate the network capture process
-        network_traffic_capture_process.terminate()
     if run_as_test:
         network_traffic_capture_process.terminate()
     # without ci it will be terminate after a few seconds, it needs to kill the tshark and update pcap file collection

--- a/core/load.py
+++ b/core/load.py
@@ -362,13 +362,16 @@ def wait_until_interrupt(virtual_machine_container_reset_factory_time_seconds, c
                 # start containers based on selected modules
                 start_containers(configuration)
             if not new_network_events_thread.is_alive():
-                return error(messages["interrupt_application"])
+                error(messages["interrupt_application"])
+                return True
+
             if containers_are_unhealthy(configuration):
-                return error(
+                error(
                     "Interrupting the application because \"{0}\" container(s) is(are) not alive!".format(
                         ", ".join(containers_are_unhealthy(configuration))
                     )
                 )
+                return True
             if run_as_test:
                 break
         except KeyboardInterrupt:
@@ -884,6 +887,9 @@ def load_honeypot_engine():
     )
     # killed the network traffic capture process by ctrl + c... waiting to end.
     info(messages["killing_capture_process"])
+    if exit_flag:
+        # Terminate the network capture process
+        network_traffic_capture_process.terminate()
     if run_as_test:
         network_traffic_capture_process.terminate()
     # without ci it will be terminate after a few seconds, it needs to kill the tshark and update pcap file collection


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix network thread issue

Issue is network thread is not terminating after an error
to reproduce the issue, run a module, and then kill the container with docker kill container_name. OHP is expected to exit from working and throw an error, but the network thread stays open and it's not terminating.


## Steps to Reproduce
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
```sh
# run the command below
$ sudo python3 ohp.py -m ftp/weak_password,ftp/strong_password --store-pcap
# wait until network capture process starts
```
```sh
# on new terminal run the command below
$ docker kill ohp_ftpserver_strong_password
# on the terminal where you started the capture process it will not end but it should.
```



## Related Issue
<!--- Please add link to the issue here, if related to a issue -->
#359 

## Screenshots (if appropriate):
<img width="805" alt="Screenshot 2022-08-02 at 10 18 45 AM" src="https://user-images.githubusercontent.com/53966291/182294493-42311951-5088-4d50-a5c8-8c9dd47bbee1.png">
After killing the container the network capture process terminates successfully.
<img width="1350" alt="Screenshot 2022-08-02 at 10 18 52 AM" src="https://user-images.githubusercontent.com/53966291/182294502-392b3d47-f72e-433f-8d79-bea9c2d7cbe4.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have referenced the corresponding issue number in my commit message
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.
